### PR TITLE
Fix/service imports

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -15,6 +15,7 @@ if (existsSync(srcPath)) {
   spawn("npx", ["tsx", srcPath, ...process.argv.slice(2)], {
     stdio: "inherit",
     shell: true,
+    cwd: __dirname,
   });
 } else {
   // Production: import compiled JavaScript

--- a/src/core/factories/ResourceRestoreServiceFactory.ts
+++ b/src/core/factories/ResourceRestoreServiceFactory.ts
@@ -1,5 +1,6 @@
 import { glob } from "glob";
-import path from "path";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
 import type { Context } from "../types/context";
 import type { ResourceType } from "../types/types";
 import type { ResourceRestoreService } from "../services/ResourceRestoreService";
@@ -14,15 +15,19 @@ export class ResourceRestoreServiceFactory {
   constructor(private services: ResourceRestoreServiceCreator[]) {}
 
   static async create() {
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = dirname(__filename);
+    const resourcesDir = join(__dirname, "../../resources");
+    const ext = __filename.endsWith(".ts") ? ".ts" : ".js";
     const serviceFiles = (
-      await glob("@resources/**/*RestoreService.ts")
-    ).filter((file) => !file.endsWith("ResourceCollectionRestoreService.ts"));
+      await glob(join(resourcesDir, `**/*RestoreService${ext}`))
+    ).filter((file) => !file.endsWith(`ResourceCollectionRestoreService${ext}`));
 
     logger.debug("ResourceRestore service files", serviceFiles);
 
     const creators = await Promise.all(
       serviceFiles.map(async (file) => {
-        const module = await import(path.resolve(file));
+        const module = await import(file);
         const ServiceClass = module.default;
 
         const resourceType = ServiceClass.RESOURCE_TYPE;


### PR DESCRIPTION
When running the CLI from a directory other than the repo's root (such as via `npx`), the various service imports are not found. This fixes that.